### PR TITLE
add day toggle

### DIFF
--- a/App.js
+++ b/App.js
@@ -1,15 +1,39 @@
 import { Calendar, toDateId, CalendarTheme } from "@marceloterreiro/flash-calendar";
 import { StatusBar } from 'expo-status-bar';
 import { StyleSheet, Text, View } from 'react-native';
+import React, { useState } from 'react';
 
 const today = toDateId(new Date());
 
+let selectedDates = new Set();
+
 export default function App() {
+  const [dates, setDates] = useState(new Set());
+
+  function datesToRanges(dates) {
+    return Array.from(selectedDates).map((date) => {
+      return { startId: date, endId: date };
+    });
+  }
+
+  function handleClick(date) {
+    if (selectedDates.has(date)) {
+      selectedDates.delete(date);
+    } else {
+      selectedDates.add(date);
+    }
+    setDates(new Set(selectedDates));
+  }
+
+  let dateRanges = datesToRanges(dates);
+
   return (
     <View style={styles.container}>
       <Calendar
         calendarMonthId={today}
         theme={linearTheme}
+        calendarActiveDateRanges={dateRanges}
+        onCalendarDayPress={handleClick}
         />
       <StatusBar style="auto" />
     </View>
@@ -33,5 +57,4 @@ let styles = StyleSheet.create({
     backgroundColor: 'pink',
     paddingTop: 80,
   },
-  
 });


### PR DESCRIPTION
These changes use the React [useState()](https://react.dev/reference/react/useState) method to update a list of dates that are drinking days. 

It then converts that set into the format that is expected by the [calendarActiveDateRanges prop](https://marceloprado.github.io/flash-calendar/fundamentals/usage) to highlight the toggled days.